### PR TITLE
Fixed missing closing parenthesis in inline example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ int main() {
   // Patch into empty DOM element – this modifies the DOM as a side effect
   patch(
     emscripten::val::global("document").call<emscripten::val>(
-    "getElementById",
-    std::string("root"),
+      "getElementById",
+      std::string("root")
+    ),
     vnode
   );
 

--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -59,8 +59,9 @@ int main() {
   // Patch into empty DOM element – this modifies the DOM as a side effect
   patch(
     emscripten::val::global("document").call<emscripten::val>(
-    "getElementById",
-    std::string("root"),
+      "getElementById",
+      std::string("root")
+    ),
     vnode
   );
 


### PR DESCRIPTION
Fixed missing closing parenthesis in inline example. Also slightly improved indentation.

Closes #7